### PR TITLE
Use defaults alias in yaml example instead of default

### DIFF
--- a/config/database.example.yml
+++ b/config/database.example.yml
@@ -7,9 +7,9 @@ defaults: &defaults
   password: <your_password_or_remove_this_entire_entry_if_you_dont_have_one>
 
 development:
-  <<: *default
+  <<: *defaults
   database: orlando-walking-tours-rails_development
 
 test:
-  <<: *default
+  <<: *defaults
   database: orlando-walking-tours-rails_test


### PR DESCRIPTION
Change the default alias used by both development and test environments
to match the defaults key at the top of the database.example.yml file.

The default alias causes this error:
![terminal_ _zsh_ _zsh_ _91x24_and_terminal_ _tmux_ _zsh_ _130x24](https://cloud.githubusercontent.com/assets/1418318/6479233/324ea436-c210-11e4-90d8-11d5a2365af5.png)

I'm hoping to prevent bad things from happening to others using the example yaml as a reference.
